### PR TITLE
Do not recommend "X-" prefixed headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+*.iml
+.metadata
+.settings

--- a/proposals/0009-LRA/0009-LRA.md
+++ b/proposals/0009-LRA/0009-LRA.md
@@ -128,7 +128,7 @@ If an annotation causes an LRA to be started it will be ended when the bean meth
  
 If there is an LRA present when a bean method is invoked it will still be active when the method finishes. This behaviour can be overridden by setting the terminal element to true.
  
-When an LRA is present it should be made available to the business logic via request and response headers (with the name "X-lra")
+When an LRA is present it should be made available to the business logic via request and response headers (with the name "Long-Running-Action")
  
 Example:
  
@@ -165,7 +165,7 @@ Similarly the @LRACompensatorCompensate method will be invoked if the LRA is can
   @Path("/compensate")
   @Produces(MediaType.APPLICATION_JSON)
   @LRACompensatorCompensate
-  public Response compensateWork(@HeaderParam("X-lra") String lraId) {
+  public Response compensateWork(@HeaderParam("Long-Running-Action") String lraId) {
     // compensate for whatever activity the business logic has associated with lraId
   }
 ```
@@ -379,7 +379,7 @@ Once the LRA terminates the implementation may retain information about it for a
 
 ##### Compensators
  
-When making an invocation on a resource that needs to participate in a LRA, the LRA context (the LRA URL) needs to be transmitted to the resource. How this happens is outside the scope of this effort. It may occur as additional payload on the initial request such as in an HTTP header, or it may be that the client sends the context out-of-band to the resource. *To facilitate interoperability between different implementations of this specification we recommend that the context is passed using an HTTP header with name the name "X-lra"*
+When making an invocation on a resource that needs to participate in a LRA, the LRA context (the LRA URL) needs to be transmitted to the resource. How this happens is outside the scope of this effort. It may occur as additional payload on the initial request such as in an HTTP header, or it may be that the client sends the context out-of-band to the resource. *To facilitate interoperability between different implementations of this specification we recommend that the context is passed using an HTTP header with the name "Long-Running-Action"*
  
 Once a resource has the LRA context, it can register participation in the LRA (ie enlist the compensator). The compensator is free to use whatever URL structure it desires for uniquely identifying itself with the constraint that it must be unique for the LRA (ie the same compensator cannot be involved in more than one LRA). The \<compensator URL\> must support the following operations:
  
@@ -449,7 +449,7 @@ A SRA is created by POSTing to the SRA manager URL which returns a URL for the n
 
 ## Transaction Context Propagation
 
-When services interact the receiving service may need to join the SRA and to do that it needs the enlistment URL. How it obtains the enlistment URL is unspecified but, for the purposes of interoperability, we recommend that it is propagated via an HTTP header with the name "X-sra". Once the receiving service has the url it issues a PUT request and includes a link header that contains the prepare, commit, rollback and optionally commit-one-phase URLs that the coordinator will subsequently use to drive the participant to completion.
+When services interact the receiving service may need to join the SRA and to do that it needs the enlistment URL. How it obtains the enlistment URL is unspecified but, for the purposes of interoperability, we recommend that it is propagated via an HTTP header with the name "Short-Running-Action". Once the receiving service has the url it issues a PUT request and includes a link header that contains the prepare, commit, rollback and optionally commit-one-phase URLs that the coordinator will subsequently use to drive the participant to completion.
 
 ## CDI Annotations for SRAs
 lra-annotations/src/main/java/org/eclipse/microprofile/lra/annotation

--- a/proposals/0009-LRA/0009-LRA.md
+++ b/proposals/0009-LRA/0009-LRA.md
@@ -469,7 +469,7 @@ The lifecycle of a SRA is controlled using an annotation called SRA which is bro
  * An annotation for controlling the lifecycle of Short Running Actions (SRAs).
  *
  * Newly created SRAs are uniquely identified and the id is referred to as the SRA context. The context
- * is passed around using a JAX-RS request/response header called SRAClient#SRA_HTTP_HEADER ("X-sra").
+ * is passed around using a JAX-RS request/response header called SRAClient#SRA_HTTP_HEADER ("Short-Running-Action").
  * The implementation (of the SRA specification) is expected to manage this context and the application
  * developer is expected to declaratively control the creation, propagation and destruction of SRAs
  * using this @SRA annotation. When a JAX-RS bean method is invoked in the context of an SRA any JAX-RS

--- a/proposals/0009-LRA/lra-annotations/src/main/java/org/eclipse/microprofile/lra/annotation/LRA.java
+++ b/proposals/0009-LRA/lra-annotations/src/main/java/org/eclipse/microprofile/lra/annotation/LRA.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * An annotation for controlling the lifecycle of Long Running Actions (LRAs).
  *
  * Newly created LRAs are uniquely identified and the id is referred to as the LRA context. The context is passed around
- * using a JAX-RS request/response header called LRAClient#LRA_HTTP_HEADER ("X-lra"). The implementation (of the LRA
+ * using a JAX-RS request/response header called LRAClient#LRA_HTTP_HEADER ("Long-Running-Action"). The implementation (of the LRA
  * specification) is expected to manage this context and the application developer is expected to declaratively control
  * the creation, propagation and destruction of LRAs using the @LRA annotation. When a JAX-RS bean method is invoked in the
  * context of an LRA any JAX-RS client requests that it performs will carry the same header so that the receiving

--- a/proposals/0009-LRA/sra-annotations/src/main/java/org/eclipse/microprofile/sra/annotation/SRA.java
+++ b/proposals/0009-LRA/sra-annotations/src/main/java/org/eclipse/microprofile/sra/annotation/SRA.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * An annotation for controlling the lifecycle of Short Running Actions (SRAs).
  *
  * Newly created SRAs are uniquely identified and the id is referred to as the SRA context. The context
- * is passed around using a JAX-RS request/response header called SRAClient#SRA_HTTP_HEADER ("X-sra").
+ * is passed around using a JAX-RS request/response header called SRAClient#SRA_HTTP_HEADER ("Short-Running-Action").
  * The implementation (of the SRA specification) is expected to manage this context and the application
  * developer is expected to declaratively control the creation, propagation and destruction of SRAs
  * using the @SRA annotation. When a JAX-RS bean method is invoked in the context of an SRA any JAX-RS


### PR DESCRIPTION
A small change to the spec in order to use "Long-Running-Action" and "Short-Running-Action" headers instead of "X-lra" and "X-sra".
"X-" prefixed headers should be deprecated by [RFC-6648](https://tools.ietf.org/html/rfc6648) and [RFC-7231](https://tools.ietf.org/html/rfc7231.html#section-8.3.1).

They are not mandated by this spec, but they'll be used by microprofile rest services, so it's important for other technologies to use them if they want to build interoperable rest services.